### PR TITLE
refactor: extract shared utilities, add tests and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.9"
+
+      - name: Install dependencies
+        run: |
+          pip install numpy imageio Pillow natsort tqdm pytest
+
+      - name: Run tests
+        run: pytest tests/ -v

--- a/README.md
+++ b/README.md
@@ -56,19 +56,42 @@ conda activate InterpolAI
 Please download the model folder from the following Google Drive link: [model](https://drive.google.com/drive/folders/16a4zhopq8AfKCADXxBwuYccGr_PnBRlt?usp=sharing)  
 Once downloaded please place the model folder inside  the interpolation directory of the InterpolAI repository. 
 ## Usage
-In the interpolation folder, you can find individual executable jupyter notebooks as listed:
-1. `interpolAI_auto.ipynb` : loads and reads through a folder of images and detects missing images using filenames in the folder, algorithm will then generate the missing images.
-- **OR** run the following main.py with mode auto
-```bash
-python main.py --mode auto --tile_size 1024 1024 --pth "\\10.99.68.178\Saurabh\manuscript_figs\data\HE_roi1\authentic\test"
+
+In the interpolation folder, you can find individual executable Jupyter notebooks as listed:
+
+1. `interpolAI_auto.ipynb` : Detects missing images from filenames and generates them automatically.
+   - **OR** run from the CLI with mode `auto`:
+   ```bash
+   python main.py --mode auto --tile_size 1024 1024 --pth /path/to/your/images
+   ```
+   Add `--output /path/to/output` to write results to a separate folder.
+
+2. `interpolAI_no_skip.ipynb`: Generates a given number of intermediate frames between every consecutive image pair.
+   - **OR** run from the CLI with mode `no_skip`:
+   ```bash
+   python main.py --mode no_skip --tile_size 1024 1024 --pth /path/to/your/images --skip 1 3 5
+   ```
+
+3. `interpolAI_skip_haralick.ipynb`: Skips images in the folder and generates the skipped frames.
+   - **OR** run from the CLI with mode `skip`:
+   ```bash
+   python main.py --mode skip --tile_size 1024 1024 --pth /path/to/your/images --skip 1
+   ```
+
+### CLI reference
+
 ```
-2. `interpolAI_no_skip.ipynb`: loads and reads through a folder of images, algorithm will then generate a given number of images, as defined by users the skip flag, between each pair of images in the input folder. 
-- **OR** run the following main.py with mode no_skip
-```bash
-python main.py --mode no_skip --tile_size 1024 1024 --pth "\\10.99.68.178\Saurabh\manuscript_figs\data\HE_roi1\authentic\test" --skip 1 3 5 
+python main.py --mode {auto,no_skip,skip}
+               --tile_size H W
+               --pth PATH
+               [--output OUTPUT_DIR]
+               [--skip N [N ...]]
 ```
-3. `interpolAI_skip_haralick.ipynb`: loads and reads through a folder of images, algorithm will then skip images in the folder and generate the skipped images, as defined by the users skip flag. 
-- **OR** run the following main.py with mode skip
-```bash
-python main.py --mode skip --tile_size 1024 1024 --pth "\\10.99.68.178\Saurabh\manuscript_figs\data\HE_roi1\authentic\test" --skip 1
-```
+
+| Flag | Description |
+|---|---|
+| `--mode` | `auto` detects gaps; `no_skip` inserts frames between every pair; `skip` pairs images separated by a given distance |
+| `--tile_size` | Tile size for large images (height width). Use 1024 1024 as a starting point. |
+| `--pth` | Path to folder containing input images (.tif / .png / .jpg) |
+| `--output` | Output root folder for generated subfolders (default: same as `--pth`) |
+| `--skip` | One or more skip values (used by `no_skip` and `skip` modes) |

--- a/interpolation/__init__.py
+++ b/interpolation/__init__.py
@@ -1,0 +1,24 @@
+from .utils import (
+    extract_number_from_filename,
+    get_file_extension,
+    load_image,
+    make_output_filename,
+    pad_and_tile_image,
+    stitch_tiles,
+)
+from .interpolation_function_auto import interpolate_from_image_list, list_skip_images
+from .interpolation_function_skip import interpolate_from_image_stack_skip
+from .interpolation_functions_no_skip import interpolate_from_image_stack_no_skip
+
+__all__ = [
+    "extract_number_from_filename",
+    "get_file_extension",
+    "interpolate_from_image_list",
+    "interpolate_from_image_stack_no_skip",
+    "interpolate_from_image_stack_skip",
+    "list_skip_images",
+    "load_image",
+    "make_output_filename",
+    "pad_and_tile_image",
+    "stitch_tiles",
+]

--- a/interpolation/interpolation_function_auto.py
+++ b/interpolation/interpolation_function_auto.py
@@ -1,92 +1,71 @@
-import numpy as np
 import os
-import tensorflow as tf
+
 import imageio
-from PIL import Image
+import numpy as np
 from natsort import natsorted
 from tqdm import tqdm
-import time
-import re
 
-Image.MAX_IMAGE_PIXELS = None
+from .utils import (
+    _UINT8_MAX_F,
+    extract_number_from_filename,
+    get_file_extension,
+    load_image,
+    make_output_filename,
+    pad_and_tile_image,
+    stitch_tiles,
+)
 
-def load_image(img_path: str):
-    _UINT8_MAX_F = float(np.iinfo(np.uint8).max)
-    image = imageio.imread(img_path)
-    image = image.astype(np.float32) / _UINT8_MAX_F
-    return image
 
-def get_file_extension(filename):
-    return os.path.splitext(filename)[1]
+def list_skip_images(pthims: str) -> dict:
+    """Detect missing images in a numbered sequence.
 
-def pad_and_tile_image(image: np.ndarray, tile_size: tuple):
-    h, w, _ = image.shape
-    tile_height, tile_width = tile_size
-    pad_h = (tile_height - h % tile_height) % tile_height
-    pad_w = (tile_width - w % tile_width) % tile_width
-    padded_image = np.pad(image, pad_width=[(0, pad_h), (0, pad_w), (0, 0)], mode='constant', constant_values=0)
-    padded_height, padded_width, _ = padded_image.shape
-    tiled_array = padded_image.reshape(padded_height // tile_height,
-                                       tile_height,
-                                       padded_width // tile_width,
-                                       tile_width,
-                                       -1)
-    tiled_array = tiled_array.swapaxes(1, 2)
-    return tiled_array, (pad_h, pad_w)
-
-def stitch_tiles(tiles: np.ndarray, pad_h: int, pad_w: int, tile_size: tuple):
-    tile_height, tile_width = tile_size
-    tile_rows, tile_cols, _, _, _ = tiles.shape
-    stitched_image = tiles.swapaxes(1, 2).reshape(tile_rows * tile_height, tile_cols * tile_width, -1)
-    if pad_h > 0 or pad_w > 0:
-        stitched_image = stitched_image[:-pad_h or None, :-pad_w or None]
-
-    return stitched_image
-def extract_number_from_filename(filename):
-    match = re.search(r'(\d+)(?=\D*$)', filename)  # Extract last number in filename
-    return int(match.group(1)) if match else None
-
-def list_skip_images(pthims):
-    image_files = [f for f in os.listdir(pthims) if f.endswith(('tif', 'png', 'jpg'))]
-
-    # Extract numeric values from filenames
+    Returns a dict mapping skip_index -> list of [prev_num, next_num] pairs
+    that bracket each gap.
+    """
+    image_files = [f for f in os.listdir(pthims) if f.endswith(("tif", "png", "jpg"))]
     list_z_nums = sorted(filter(None, [extract_number_from_filename(f) for f in image_files]))
 
-    # Identify missing numbers in the sequence
     full_range = set(range(min(list_z_nums), max(list_z_nums) + 1))
     missing_numbers = sorted(full_range - set(list_z_nums))
 
-    # Create input image pairs for each missing number
-    skip_inputs = {}
-    added_pairs = set()  # To track unique pairs
+    skip_inputs: dict = {}
+    added_pairs: set = set()
 
     for missing in missing_numbers:
-        prev_image = max([num for num in list_z_nums if num < missing], default=None)
-        next_image = min([num for num in list_z_nums if num > missing], default=None)
+        prev_image = max([n for n in list_z_nums if n < missing], default=None)
+        next_image = min([n for n in list_z_nums if n > missing], default=None)
 
         if prev_image is not None and next_image is not None:
-            skip_index = next_image - prev_image - 1  # Defines the "skip" level
+            skip_index = next_image - prev_image - 1
             pair = (prev_image, next_image)
-
             if skip_index not in skip_inputs:
                 skip_inputs[skip_index] = []
-
-            if pair not in added_pairs:  # Ensure uniqueness
+            if pair not in added_pairs:
                 skip_inputs[skip_index].append([prev_image, next_image])
                 added_pairs.add(pair)
 
     return skip_inputs
 
-def interpolate_from_image_list(pthims, skip_images, TILE_SIZE, model, image_files):
-    _UINT8_MAX_F = float(np.iinfo(np.uint8).max)
-    image_files = natsorted(image_files)  # Sort image files naturally
-    file_extension = get_file_extension(image_files[0])  # Get file extension
-    image_dict = {extract_number_from_filename(f): f for f in image_files}  # Map numbers to filenames
-    image2 = None  # Initialize image2 to None
+
+def interpolate_from_image_list(pthims, skip_images, TILE_SIZE, model, image_files, output_dir=None):
+    """Interpolate missing frames detected automatically by list_skip_images.
+
+    Args:
+        pthims: path to the folder containing source images.
+        skip_images: dict returned by list_skip_images.
+        TILE_SIZE: (height, width) tile size for large images.
+        model: loaded TensorFlow saved model.
+        image_files: list of image filenames in pthims.
+        output_dir: root folder for output subfolders.  Defaults to pthims.
+    """
+    base_output = output_dir or pthims
+    image_files = natsorted(image_files)
+    file_extension = get_file_extension(image_files[0])
+    image_dict = {extract_number_from_filename(f): f for f in image_files}
 
     for skip_num, image_pairs in skip_images.items():
-        print(f'Interpolating for skip {skip_num}:')
-        output_folder = os.path.join(pthims, f'int_{skip_num}')
+        print(f"Interpolating for skip {skip_num}:")
+        output_folder = os.path.join(base_output, f"int_{skip_num}")
         os.makedirs(output_folder, exist_ok=True)
         times = np.linspace(0, 1, skip_num + 2)[1:-1]
 
@@ -94,96 +73,68 @@ def interpolate_from_image_list(pthims, skip_images, TILE_SIZE, model, image_fil
             image1_path = os.path.join(pthims, image_dict[img1_num])
             image2_path = os.path.join(pthims, image_dict[img2_num])
 
-            # Check if all output images already exist
-            all_exist = True
-            for idx, time_value in enumerate(times):
-                base_name, ext = os.path.splitext(image_dict[img1_num])
-                match = re.search(r'(\d+)$', base_name)
-                if match:
-                    number_part = match.group(1)
-                    new_number = str(int(number_part) + (idx + 1)).zfill(len(number_part))
-                    filename = f"{base_name[:-len(number_part)]}{new_number}{file_extension}"
-                else:
-                    filename = f"{base_name}_int{idx + 1}{file_extension}"
-                output_path = os.path.join(output_folder, filename)
-                if not os.path.exists(output_path):
-                    all_exist = False
-                    break
-
+            all_exist = all(
+                os.path.exists(
+                    os.path.join(output_folder, make_output_filename(image_dict[img1_num], idx, file_extension))
+                )
+                for idx in range(len(times))
+            )
             if all_exist:
-                print(f'All interpolated images from {image_dict[img1_num]} and {image_dict[img2_num]} already exist. Skipping...')
+                print(
+                    f"All interpolated images from {image_dict[img1_num]} and "
+                    f"{image_dict[img2_num]} already exist. Skipping..."
+                )
                 continue
 
             image1 = load_image(image1_path)
             image2 = load_image(image2_path)
 
-            if max(image1.shape[:2]) > TILE_SIZE[0] or max(image2.shape[:2]) > TILE_SIZE[1]:
-                print('Stitching needed')
+            needs_tiling = max(image1.shape[:2]) > TILE_SIZE[0] or max(image2.shape[:2]) > TILE_SIZE[1]
+
+            if needs_tiling:
+                print("Stitching needed")
                 tiles1, (pad_h, pad_w) = pad_and_tile_image(image1, TILE_SIZE)
                 tiles2, _ = pad_and_tile_image(image2, TILE_SIZE)
                 tile_height, tile_width = TILE_SIZE
                 num_channels = image1.shape[-1]
                 tile_rows, tile_cols, _, _, _ = tiles1.shape
-            else:
-                print('No stitching needed')
+
                 with tqdm(total=len(times), desc=f"Interpolating {image_dict[img1_num]}", unit="frame") as pbar:
                     for idx, time_value in enumerate(times):
-                        base_name, ext = os.path.splitext(image_dict[img1_num])
-                        match = re.search(r'(\d+)$', base_name)
-                        if match:
-                            number_part = match.group(1)
-                            new_number = str(int(number_part) + (idx + 1)).zfill(len(number_part))
-                            filename = f"{base_name[:-len(number_part)]}{new_number}{file_extension}"
-                        else:
-                            filename = f"{base_name}_int{idx + 1}{file_extension}"
+                        tiles_out = []
+                        for tile_row in range(tile_rows):
+                            for tile_col in range(tile_cols):
+                                input_data = {
+                                    "time": np.array([[time_value]], dtype=np.float32),
+                                    "x0": np.expand_dims(tiles1[tile_row, tile_col], axis=0),
+                                    "x1": np.expand_dims(tiles2[tile_row, tile_col], axis=0),
+                                }
+                                generated = model(input_data)["image"][0].numpy()
+                                tile_uint8 = (np.clip(generated * _UINT8_MAX_F, 0, _UINT8_MAX_F) + 0.5).astype(np.uint8)
+                                tiles_out.append(tile_uint8)
+
+                        filename = make_output_filename(image_dict[img1_num], idx, file_extension)
+                        tiles_np = np.array(tiles_out).reshape(tile_rows, tile_cols, tile_height, tile_width, num_channels)
+                        stitched = stitch_tiles(tiles_np, pad_h, pad_w, TILE_SIZE)
+                        imageio.imwrite(os.path.join(output_folder, filename), stitched, format=file_extension.lstrip("."))
+                        pbar.update(1)
+            else:
+                print("No stitching needed")
+                with tqdm(total=len(times), desc=f"Interpolating {image_dict[img1_num]}", unit="frame") as pbar:
+                    for idx, time_value in enumerate(times):
+                        filename = make_output_filename(image_dict[img1_num], idx, file_extension)
                         output_path = os.path.join(output_folder, filename)
                         if os.path.exists(output_path):
-                            print(f'Already interpolated from {image_dict[img1_num]} and {image_dict[img2_num]}')
+                            print(f"Already interpolated from {image_dict[img1_num]} and {image_dict[img2_num]}")
                             pbar.update(1)
                             continue
-                        time1 = np.array([time_value], dtype=np.float32)
+
                         input_data = {
-                            'time': np.array([time1], dtype=np.float32),
-                            'x0': np.expand_dims(image1, axis=0),
-                            'x1': np.expand_dims(image2, axis=0)
+                            "time": np.array([[time_value]], dtype=np.float32),
+                            "x0": np.expand_dims(image1, axis=0),
+                            "x1": np.expand_dims(image2, axis=0),
                         }
-                        mid_frame = model(input_data)
-                        generated_image = mid_frame['image'][0].numpy()
-                        image_in_uint8_range = np.clip(generated_image * _UINT8_MAX_F, 0.0, _UINT8_MAX_F)
-                        image_in_uint8 = (image_in_uint8_range + 0.5).astype(np.uint8)
-                        imageio.imwrite(output_path, image_in_uint8, format=file_extension.lstrip('.'))
+                        generated = model(input_data)["image"][0].numpy()
+                        image_uint8 = (np.clip(generated * _UINT8_MAX_F, 0, _UINT8_MAX_F) + 0.5).astype(np.uint8)
+                        imageio.imwrite(output_path, image_uint8, format=file_extension.lstrip("."))
                         pbar.update(1)
-                continue
-
-            with tqdm(total=len(times), desc=f"Interpolating {image_dict[img1_num]}", unit="frame") as pbar:
-                for idx, time_value in enumerate(times):
-                    tiles_dict = []
-                    for tile_row in range(tile_rows):
-                        for tile_col in range(tile_cols):
-                            tile1 = tiles1[tile_row, tile_col]
-                            tile2 = tiles2[tile_row, tile_col]
-                            time1 = np.array([time_value], dtype=np.float32)
-                            input_data = {
-                                'time': np.array([time1], dtype=np.float32),
-                                'x0': np.expand_dims(tile1, axis=0),
-                                'x1': np.expand_dims(tile2, axis=0)
-                            }
-                            mid_frame = model(input_data)
-                            generated_tile = mid_frame['image'][0].numpy()
-                            image_in_uint8_range = np.clip(generated_tile * _UINT8_MAX_F, 0.0, _UINT8_MAX_F)
-                            image_in_uint8 = (image_in_uint8_range + 0.5).astype(np.uint8)
-                            tiles_dict.append(image_in_uint8)
-                    base_name, ext = os.path.splitext(image_dict[img1_num])
-                    match = re.search(r'(\d+)$', base_name)
-                    if match:
-                        number_part = match.group(1)
-                        new_number = str(int(number_part) + (idx + 1)).zfill(len(number_part))
-                        stitched_filename = f"{base_name[:-len(number_part)]}{new_number}{file_extension}"
-                    else:
-                        stitched_filename = f"{base_name}_int{idx + 1}{file_extension}"
-                    stitched_output_path = os.path.join(output_folder, stitched_filename)
-                    interpolated_tiles_np = np.array(tiles_dict).reshape(tile_rows, tile_cols, tile_height, tile_width, num_channels)
-                    stitched_image = stitch_tiles(interpolated_tiles_np, pad_h, pad_w, TILE_SIZE)
-                    imageio.imwrite(stitched_output_path, stitched_image, format=file_extension.lstrip('.'))
-                    pbar.update(1)
-

--- a/interpolation/interpolation_function_skip.py
+++ b/interpolation/interpolation_function_skip.py
@@ -1,173 +1,114 @@
 import os
-import numpy as np
+import time
+
 import imageio
-import tensorflow as tf
+import numpy as np
 from natsort import natsorted
 from tqdm import tqdm
-import time
-# import cv2
-# import mahotas
-# import pandas as pd
-# import csv
 
-def load_image(img_path: str):
-    _UINT8_MAX_F = float(np.iinfo(np.uint8).max)
-    image = imageio.imread(img_path)
-    image = image.astype(np.float32) / _UINT8_MAX_F
-    return image
+from .utils import (
+    _UINT8_MAX_F,
+    get_file_extension,
+    load_image,
+    pad_and_tile_image,
+    stitch_tiles,
+)
 
-def get_file_extension(filename):
-    return os.path.splitext(filename)[1]
 
-def pad_and_tile_image(image: np.ndarray, tile_size: tuple):
-    h, w, _ = image.shape
-    tile_height, tile_width = tile_size
-    pad_h = (tile_height - h % tile_height) % tile_height
-    pad_w = (tile_width - w % tile_width) % tile_width
-    padded_image = np.pad(image, pad_width=[(0, pad_h), (0, pad_w), (0, 0)], mode='constant', constant_values=0)
-    padded_height, padded_width, _ = padded_image.shape
-    tiled_array = padded_image.reshape(padded_height // tile_height,
-                                       tile_height,
-                                       padded_width // tile_width,
-                                       tile_width,
-                                       -1)
-    tiled_array = tiled_array.swapaxes(1, 2)
-    return tiled_array, (pad_h, pad_w)
+def interpolate_from_image_stack_skip(pthims, skip_values, TILE_SIZE, model, image_files=None, output_dir=None):
+    """Interpolate frames between pairs separated by a given skip distance.
 
-def stitch_tiles(tiles: np.ndarray, pad_h: int, pad_w: int, tile_size: tuple):
-    tile_height, tile_width = tile_size
-    tile_rows, tile_cols, _, _, _ = tiles.shape
-    stitched_image = tiles.swapaxes(1, 2).reshape(tile_rows * tile_height, tile_cols * tile_width, -1)
-    if pad_h > 0 or pad_w > 0:
-        stitched_image = stitched_image[:-pad_h or None, :-pad_w or None]
+    For each skip value n, pairs image[i] with image[i + n + 1] and generates
+    n intermediate frames between them.
 
-    return stitched_image
-
-def interpolate_from_image_stack_skip(pthims, skip_values, TILE_SIZE, model, image_files=None):
-    _UINT8_MAX_F = float(np.iinfo(np.uint8).max)
-    image_files = [f for f in os.listdir(pthims) if f.endswith(('tif', 'png', 'jpg'))]
-    image_files = natsorted(image_files)
+    Args:
+        pthims: path to source image folder.
+        skip_values: list of skip distances to process.
+        TILE_SIZE: (height, width) tile size for large images.
+        model: loaded TensorFlow saved model.
+        image_files: unused; kept for API compatibility.
+        output_dir: root folder for output subfolders.  Defaults to pthims.
+    """
+    base_output = output_dir or pthims
+    image_files = natsorted([f for f in os.listdir(pthims) if f.endswith(("tif", "png", "jpg"))])
     file_extension = get_file_extension(image_files[0])
     image2 = None
 
     for skip_num in skip_values:
-        print(f'Interpolating int {skip_num} with skip {skip_num}:')
-        output_folder = os.path.join(pthims, f'int_{skip_num}_skip_{skip_num}')
+        print(f"Interpolating int {skip_num} with skip {skip_num}:")
+        output_folder = os.path.join(base_output, f"int_{skip_num}_skip_{skip_num}")
         os.makedirs(output_folder, exist_ok=True)
         times = np.linspace(0, 1, skip_num + 2)[1:-1]
 
-        for i in range(0, len(image_files) - (skip_num + 1)):
+        for i in range(len(image_files) - (skip_num + 1)):
             image1_path = os.path.join(pthims, image_files[i])
             image2_path = os.path.join(pthims, image_files[i + skip_num + 1])
 
-            output_checkpath = os.path.join(output_folder, f"{os.path.splitext(image_files[i])[0]}_to_{os.path.splitext(image_files[i + skip_num + 1])[0]}_int{skip_num}{file_extension}")
+            stem1 = os.path.splitext(image_files[i])[0]
+            stem2 = os.path.splitext(image_files[i + skip_num + 1])[0]
+            output_checkpath = os.path.join(output_folder, f"{stem1}_to_{stem2}_int{skip_num}{file_extension}")
             if os.path.exists(output_checkpath):
-                print(f'already interpolated from input images {image_files[i]} and {image_files[i + skip_num + 1]}')
+                print(f"Already interpolated from {image_files[i]} and {image_files[i + skip_num + 1]}")
                 continue
 
             if image2 is not None:
-                print('loading image 1 from image 2')
                 image1 = image2
             else:
                 image1 = load_image(image1_path)
-
             image2 = load_image(image2_path)
 
-            if max(image1.shape[:2]) > TILE_SIZE[0] or max(image2.shape[:2]) > TILE_SIZE[1]:
-                print('stitching')
+            needs_tiling = max(image1.shape[:2]) > TILE_SIZE[0] or max(image2.shape[:2]) > TILE_SIZE[1]
+
+            if needs_tiling:
+                print("Stitching needed")
                 tiles1, (pad_h, pad_w) = pad_and_tile_image(image1, TILE_SIZE)
                 tiles2, _ = pad_and_tile_image(image2, TILE_SIZE)
                 tile_height, tile_width = TILE_SIZE
                 num_channels = image1.shape[-1]
                 tile_rows, tile_cols, _, _, _ = tiles1.shape
-            else:
-                print('not stitching')
+
                 with tqdm(total=len(times), desc=f"Interpolating {image_files[i]} to {image_files[i + skip_num + 1]}", unit="frame") as pbar:
                     for idx, time_value in enumerate(times):
                         start_time = time.time()
-                        filename = f"{os.path.splitext(image_files[i])[0]}_to_{os.path.splitext(image_files[i + skip_num + 1])[0]}_int{idx + 1}{file_extension}"
-                        output_path = os.path.join(output_folder, filename)
+                        tiles_out = []
+                        for tile_row in range(tile_rows):
+                            for tile_col in range(tile_cols):
+                                input_data = {
+                                    "time": np.array([[time_value]], dtype=np.float32),
+                                    "x0": np.expand_dims(tiles1[tile_row, tile_col], axis=0),
+                                    "x1": np.expand_dims(tiles2[tile_row, tile_col], axis=0),
+                                }
+                                generated = model(input_data)["image"][0].numpy()
+                                tile_uint8 = (np.clip(generated * _UINT8_MAX_F, 0, _UINT8_MAX_F) + 0.5).astype(np.uint8)
+                                tiles_out.append(tile_uint8)
 
+                        filename = f"{stem1}_to_{stem2}_int{idx + 1}{file_extension}"
+                        tiles_np = np.array(tiles_out).reshape(tile_rows, tile_cols, tile_height, tile_width, num_channels)
+                        stitched = stitch_tiles(tiles_np, pad_h, pad_w, TILE_SIZE)
+                        imageio.imwrite(os.path.join(output_folder, filename), stitched, format=file_extension.lstrip("."))
+                        elapsed = time.time() - start_time
+                        print(f"Time to generate {filename}: {elapsed:.2f} seconds")
+                        pbar.update(1)
+            else:
+                print("No stitching needed")
+                with tqdm(total=len(times), desc=f"Interpolating {image_files[i]} to {image_files[i + skip_num + 1]}", unit="frame") as pbar:
+                    for idx, time_value in enumerate(times):
+                        start_time = time.time()
+                        filename = f"{stem1}_to_{stem2}_int{idx + 1}{file_extension}"
+                        output_path = os.path.join(output_folder, filename)
                         if os.path.exists(output_path):
-                            print(f'already interpolated from input images {image_files[i]} and {image_files[i + skip_num + 1]}')
+                            print(f"Already interpolated from {image_files[i]} and {image_files[i + skip_num + 1]}")
                             pbar.update(1)
                             continue
 
-                        time1 = np.array([time_value], dtype=np.float32)
                         input_data = {
-                            'time': np.array([time1], dtype=np.float32),
-                            'x0': np.expand_dims(image1, axis=0),
-                            'x1': np.expand_dims(image2, axis=0)
+                            "time": np.array([[time_value]], dtype=np.float32),
+                            "x0": np.expand_dims(image1, axis=0),
+                            "x1": np.expand_dims(image2, axis=0),
                         }
-                        mid_frame = model(input_data)
-                        generated_image = mid_frame['image'][0].numpy()
-                        image_in_uint8_range = np.clip(generated_image * _UINT8_MAX_F, 0.0, _UINT8_MAX_F)
-                        image_in_uint8 = (image_in_uint8_range + 0.5).astype(np.uint8)
-
-                        imageio.imwrite(output_path, image_in_uint8, format=file_extension.lstrip('.'))
-
-                        elapsed_time = time.time() - start_time
-                        print(f"Time to generate {filename}: {elapsed_time:.2f} seconds")
+                        generated = model(input_data)["image"][0].numpy()
+                        image_uint8 = (np.clip(generated * _UINT8_MAX_F, 0, _UINT8_MAX_F) + 0.5).astype(np.uint8)
+                        imageio.imwrite(output_path, image_uint8, format=file_extension.lstrip("."))
+                        elapsed = time.time() - start_time
+                        print(f"Time to generate {filename}: {elapsed:.2f} seconds")
                         pbar.update(1)
-                continue
-
-            with tqdm(total=len(times), desc=f"Interpolating {image_files[i]} to {image_files[i + skip_num + 1]}", unit="frame") as pbar:
-                for idx, time_value in enumerate(times):
-                    start_time = time.time()
-                    tiles_dict = []
-                    for tile_row in range(tile_rows):
-                        for tile_col in range(tile_cols):
-                            tile1 = tiles1[tile_row, tile_col]
-                            tile2 = tiles2[tile_row, tile_col]
-
-                            time1 = np.array([time_value], dtype=np.float32)
-                            input_data = {
-                                'time': np.array([time1], dtype=np.float32),
-                                'x0': np.expand_dims(tile1, axis=0),
-                                'x1': np.expand_dims(tile2, axis=0)
-                            }
-                            mid_frame = model(input_data)
-                            generated_tile = mid_frame['image'][0].numpy()
-                            image_in_uint8_range = np.clip(generated_tile * _UINT8_MAX_F, 0.0, _UINT8_MAX_F)
-                            image_in_uint8 = (image_in_uint8_range + 0.5).astype(np.uint8)
-
-                            tiles_dict.append(image_in_uint8)
-
-                    stitched_filename = f"{os.path.splitext(image_files[i])[0]}_to_{os.path.splitext(image_files[i + skip_num + 1])[0]}_int{idx + 1}{file_extension}"
-                    stitched_output_path = os.path.join(output_folder, stitched_filename)
-
-                    interpolated_tiles_np = np.array(tiles_dict).reshape(tile_rows, tile_cols, tile_height, tile_width, num_channels)
-                    stitched_image = stitch_tiles(interpolated_tiles_np, pad_h, pad_w, TILE_SIZE)
-
-                    imageio.imwrite(stitched_output_path, stitched_image, format=file_extension.lstrip('.'))
-
-                    elapsed_time = time.time() - start_time
-                    print(f"Time to generate {stitched_filename}: {elapsed_time:.2f} seconds")
-                    pbar.update(1)
-
-# def calculate_haralick(image_path):
-#     image = cv2.imread(image_path, cv2.IMREAD_GRAYSCALE)
-#     haralick_features = mahotas.features.haralick(image).mean(axis=0)
-#     return haralick_features
-#
-# def process_images_in_folder(folder_path, output_csv):
-#     image_files = [f for f in os.listdir(folder_path) if f.endswith(('.tif', '.jpg', '.png'))]
-#     csv_folder= os.path.join(folder_path,'haralick_features_quantifications')
-#     os.makedirs(csv_folder, exist_ok=True)
-#     csv_path = os.path.join(csv_folder, output_csv)  # Save CSV in the same directory as images
-#     with open(csv_path, 'w', newline='') as csv_file:
-#         writer = csv.writer(csv_file)
-#         header = ['Image'] + [f'Haralick_{i}' for i in range(13)]  # 13 Haralick features
-#         writer.writerow(header)
-#         for image_file in image_files:
-#             image_path = os.path.join(folder_path, image_file)
-#             haralick_features = calculate_haralick(image_path)
-#             row = [image_file] + list(haralick_features)
-#             writer.writerow(row)
-#
-# def process_interpolated_images_for_haralick_features(pth, skips):
-#     for skip_num in skips:
-#         # Specify the output folder for the generated middle images
-#         # output_folder = os.path.join(pth, f'skip_{skip_num}')
-#         outnm = f'skip_{skip_num}_haralick_features.csv'
-#         process_images_in_folder(pth, outnm)

--- a/interpolation/interpolation_functions_no_skip.py
+++ b/interpolation/interpolation_functions_no_skip.py
@@ -1,57 +1,42 @@
-import numpy as np
 import os
-import tensorflow as tf
-import imageio
-from PIL import Image
-from natsort import natsorted
-from tqdm import tqdm
 import time
 
-Image.MAX_IMAGE_PIXELS = None
+import imageio
+import numpy as np
+from natsort import natsorted
+from tqdm import tqdm
 
-def load_image(img_path: str):
-    _UINT8_MAX_F = float(np.iinfo(np.uint8).max)
-    image = imageio.imread(img_path)
-    image = image.astype(np.float32) / _UINT8_MAX_F
-    return image
+from .utils import (
+    _UINT8_MAX_F,
+    get_file_extension,
+    load_image,
+    pad_and_tile_image,
+    stitch_tiles,
+)
 
-def get_file_extension(filename):
-    return os.path.splitext(filename)[1]
 
-def pad_and_tile_image(image: np.ndarray, tile_size: tuple):
-    h, w, _ = image.shape
-    tile_height, tile_width = tile_size
-    pad_h = (tile_height - h % tile_height) % tile_height
-    pad_w = (tile_width - w % tile_width) % tile_width
-    padded_image = np.pad(image, pad_width=[(0, pad_h), (0, pad_w), (0, 0)], mode='constant', constant_values=0)
-    padded_height, padded_width, _ = padded_image.shape
-    tiled_array = padded_image.reshape(padded_height // tile_height,
-                                       tile_height,
-                                       padded_width // tile_width,
-                                       tile_width,
-                                       -1)
-    tiled_array = tiled_array.swapaxes(1, 2)
-    return tiled_array, (pad_h, pad_w)
+def interpolate_from_image_stack_no_skip(pthims, skips, TILE_SIZE, model, image_files=None, output_dir=None):
+    """Interpolate n frames between every consecutive image pair.
 
-def stitch_tiles(tiles: np.ndarray, pad_h: int, pad_w: int, tile_size: tuple):
-    tile_height, tile_width = tile_size
-    tile_rows, tile_cols, _, _, _ = tiles.shape
-    stitched_image = tiles.swapaxes(1, 2).reshape(tile_rows * tile_height, tile_cols * tile_width, -1)
-    if pad_h > 0 or pad_w > 0:
-        stitched_image = stitched_image[:-pad_h or None, :-pad_w or None]
+    For each skip value n, generates n frames between image[i] and image[i+1]
+    for every consecutive pair in the folder.
 
-    return stitched_image
-
-def interpolate_from_image_stack_no_skip(pthims, skips, TILE_SIZE, model, image_files=None):
-    _UINT8_MAX_F = float(np.iinfo(np.uint8).max)
-    image_files = [f for f in os.listdir(pthims) if f.endswith(('tif', 'png', 'jpg'))]
-    image_files = natsorted(image_files)
+    Args:
+        pthims: path to source image folder.
+        skips: list of interpolation counts (frames to insert between each pair).
+        TILE_SIZE: (height, width) tile size for large images.
+        model: loaded TensorFlow saved model.
+        image_files: unused; kept for API compatibility.
+        output_dir: root folder for output subfolders.  Defaults to pthims.
+    """
+    base_output = output_dir or pthims
+    image_files = natsorted([f for f in os.listdir(pthims) if f.endswith(("tif", "png", "jpg"))])
     file_extension = get_file_extension(image_files[0])
     image2 = None
 
     for skip_num in skips:
-        print(f'Interpolating int {skip_num}:')
-        output_folder = os.path.join(pthims, f'int_{skip_num}_no_skip')
+        print(f"Interpolating int {skip_num}:")
+        output_folder = os.path.join(base_output, f"int_{skip_num}_no_skip")
         os.makedirs(output_folder, exist_ok=True)
         times = np.linspace(0, 1, skip_num + 2)[1:-1]
 
@@ -59,90 +44,70 @@ def interpolate_from_image_stack_no_skip(pthims, skips, TILE_SIZE, model, image_
             image1_path = os.path.join(pthims, image_files[i])
             image2_path = os.path.join(pthims, image_files[i + 1])
 
-            output_checkpath = os.path.join(output_folder, f"{os.path.splitext(image_files[i])[0]}_int{skip_num}{file_extension}")
+            stem1 = os.path.splitext(image_files[i])[0]
+            output_checkpath = os.path.join(output_folder, f"{stem1}_int{skip_num}{file_extension}")
             if os.path.exists(output_checkpath):
-                print(f'already interpolated from input images {image_files[i]} and {image_files[i + 1]}')
+                print(f"Already interpolated from {image_files[i]} and {image_files[i + 1]}")
                 continue
 
             if image2 is not None:
-                print('loading image 1 from image 2')
                 image1 = image2
             else:
                 image1 = load_image(image1_path)
-
             image2 = load_image(image2_path)
 
-            if max(image1.shape[:2]) > TILE_SIZE[0] or max(image2.shape[:2]) > TILE_SIZE[1]:
-                print('stitching')
+            needs_tiling = max(image1.shape[:2]) > TILE_SIZE[0] or max(image2.shape[:2]) > TILE_SIZE[1]
+
+            if needs_tiling:
+                print("Stitching needed")
                 tiles1, (pad_h, pad_w) = pad_and_tile_image(image1, TILE_SIZE)
                 tiles2, _ = pad_and_tile_image(image2, TILE_SIZE)
                 tile_height, tile_width = TILE_SIZE
                 num_channels = image1.shape[-1]
                 tile_rows, tile_cols, _, _, _ = tiles1.shape
-            else:
-                print('not stitching')
+
                 with tqdm(total=len(times), desc=f"Interpolating {image_files[i]}", unit="frame") as pbar:
                     for idx, time_value in enumerate(times):
                         start_time = time.time()
-                        filename = f"{os.path.splitext(image_files[i])[0]}_int{idx + 1}{file_extension}"
-                        output_path = os.path.join(output_folder, filename)
+                        tiles_out = []
+                        for tile_row in range(tile_rows):
+                            for tile_col in range(tile_cols):
+                                input_data = {
+                                    "time": np.array([[time_value]], dtype=np.float32),
+                                    "x0": np.expand_dims(tiles1[tile_row, tile_col], axis=0),
+                                    "x1": np.expand_dims(tiles2[tile_row, tile_col], axis=0),
+                                }
+                                generated = model(input_data)["image"][0].numpy()
+                                tile_uint8 = (np.clip(generated * _UINT8_MAX_F, 0, _UINT8_MAX_F) + 0.5).astype(np.uint8)
+                                tiles_out.append(tile_uint8)
 
+                        filename = f"{stem1}_int{idx + 1}{file_extension}"
+                        tiles_np = np.array(tiles_out).reshape(tile_rows, tile_cols, tile_height, tile_width, num_channels)
+                        stitched = stitch_tiles(tiles_np, pad_h, pad_w, TILE_SIZE)
+                        imageio.imwrite(os.path.join(output_folder, filename), stitched, format=file_extension.lstrip("."))
+                        elapsed = time.time() - start_time
+                        print(f"Time to generate {filename}: {elapsed:.2f} seconds")
+                        pbar.update(1)
+            else:
+                print("No stitching needed")
+                with tqdm(total=len(times), desc=f"Interpolating {image_files[i]}", unit="frame") as pbar:
+                    for idx, time_value in enumerate(times):
+                        start_time = time.time()
+                        filename = f"{stem1}_int{idx + 1}{file_extension}"
+                        output_path = os.path.join(output_folder, filename)
                         if os.path.exists(output_path):
-                            print(f'already interpolated from input images {image_files[i]} and {image_files[i + 1]}')
+                            print(f"Already interpolated from {image_files[i]} and {image_files[i + 1]}")
                             pbar.update(1)
                             continue
 
-                        time1 = np.array([time_value], dtype=np.float32)
                         input_data = {
-                            'time': np.array([time1], dtype=np.float32),
-                            'x0': np.expand_dims(image1, axis=0),
-                            'x1': np.expand_dims(image2, axis=0)
+                            "time": np.array([[time_value]], dtype=np.float32),
+                            "x0": np.expand_dims(image1, axis=0),
+                            "x1": np.expand_dims(image2, axis=0),
                         }
-                        mid_frame = model(input_data)
-                        generated_image = mid_frame['image'][0].numpy()
-                        image_in_uint8_range = np.clip(generated_image * _UINT8_MAX_F, 0.0, _UINT8_MAX_F)
-                        image_in_uint8 = (image_in_uint8_range + 0.5).astype(np.uint8)
-
-                        imageio.imwrite(output_path, image_in_uint8, format=file_extension.lstrip('.'))
-
-                        elapsed_time = time.time() - start_time
-                        print(f"Time to generate {filename}: {elapsed_time:.2f} seconds")
+                        generated = model(input_data)["image"][0].numpy()
+                        image_uint8 = (np.clip(generated * _UINT8_MAX_F, 0, _UINT8_MAX_F) + 0.5).astype(np.uint8)
+                        imageio.imwrite(output_path, image_uint8, format=file_extension.lstrip("."))
+                        elapsed = time.time() - start_time
+                        print(f"Time to generate {filename}: {elapsed:.2f} seconds")
                         pbar.update(1)
-                continue
-
-            with tqdm(total=len(times), desc=f"Interpolating {image_files[i]}", unit="frame") as pbar:
-                for idx, time_value in enumerate(times):
-                    start_time = time.time()
-                    tiles_dict = []
-                    for tile_row in range(tile_rows):
-                        for tile_col in range(tile_cols):
-                            tile1 = tiles1[tile_row, tile_col]
-                            tile2 = tiles2[tile_row, tile_col]
-
-                            time1 = np.array([time_value], dtype=np.float32)
-                            input_data = {
-                                'time': np.array([time1], dtype=np.float32),
-                                'x0': np.expand_dims(tile1, axis=0),
-                                'x1': np.expand_dims(tile2, axis=0)
-                            }
-                            mid_frame = model(input_data)
-                            generated_tile = mid_frame['image'][0].numpy()
-                            image_in_uint8_range = np.clip(generated_tile * _UINT8_MAX_F, 0.0, _UINT8_MAX_F)
-                            image_in_uint8 = (image_in_uint8_range + 0.5).astype(np.uint8)
-
-                            tiles_dict.append(image_in_uint8)
-
-                    stitched_filename = f"{os.path.splitext(image_files[i])[0]}_int{idx + 1}{file_extension}"
-                    stitched_output_path = os.path.join(output_folder, stitched_filename)
-
-                    interpolated_tiles_np = np.array(tiles_dict).reshape(tile_rows, tile_cols, tile_height, tile_width, num_channels)
-                    stitched_image = stitch_tiles(interpolated_tiles_np, pad_h, pad_w, TILE_SIZE)
-
-                    # imageio.imwrite(stitched_output_path, stitched_image, format=file_extension.lstrip('.'),
-                    #                 jpg=True)
-
-                    imageio.imwrite(stitched_output_path, stitched_image, format=file_extension.lstrip('.'))
-
-                    elapsed_time = time.time() - start_time
-                    print(f"Time to generate {stitched_filename}: {elapsed_time:.2f} seconds")
-                    pbar.update(1)

--- a/interpolation/utils.py
+++ b/interpolation/utils.py
@@ -1,0 +1,73 @@
+import os
+import re
+
+import imageio
+import numpy as np
+from PIL import Image
+
+Image.MAX_IMAGE_PIXELS = None
+
+_UINT8_MAX_F = float(np.iinfo(np.uint8).max)
+
+
+def load_image(img_path: str) -> np.ndarray:
+    image = imageio.imread(img_path)
+    return image.astype(np.float32) / _UINT8_MAX_F
+
+
+def get_file_extension(filename: str) -> str:
+    return os.path.splitext(filename)[1]
+
+
+def pad_and_tile_image(image: np.ndarray, tile_size: tuple):
+    """Pad image to tile boundaries and reshape into a grid of tiles.
+
+    Returns:
+        tiled_array: shape (rows, cols, tile_h, tile_w, channels)
+        (pad_h, pad_w): padding added, needed to crop after stitching
+    """
+    h, w, _ = image.shape
+    tile_height, tile_width = tile_size
+    pad_h = (tile_height - h % tile_height) % tile_height
+    pad_w = (tile_width - w % tile_width) % tile_width
+    padded = np.pad(image, [(0, pad_h), (0, pad_w), (0, 0)], mode="constant", constant_values=0)
+    ph, pw, _ = padded.shape
+    tiled = padded.reshape(ph // tile_height, tile_height, pw // tile_width, tile_width, -1)
+    return tiled.swapaxes(1, 2), (pad_h, pad_w)
+
+
+def stitch_tiles(tiles: np.ndarray, pad_h: int, pad_w: int, tile_size: tuple) -> np.ndarray:
+    """Reconstruct a full image from a grid of tiles, removing any padding."""
+    tile_height, tile_width = tile_size
+    tile_rows, tile_cols, _, _, _ = tiles.shape
+    stitched = tiles.swapaxes(1, 2).reshape(tile_rows * tile_height, tile_cols * tile_width, -1)
+    if pad_h > 0 or pad_w > 0:
+        stitched = stitched[: -pad_h or None, : -pad_w or None]
+    return stitched
+
+
+def extract_number_from_filename(filename: str):
+    """Extract the last integer from a filename stem, or None if absent."""
+    match = re.search(r"(\d+)(?=\D*$)", filename)
+    return int(match.group(1)) if match else None
+
+
+def make_output_filename(source_filename: str, idx: int, file_extension: str) -> str:
+    """Generate a sequentially numbered output filename from a source filename.
+
+    The trailing number in source_filename is incremented by (idx + 1),
+    preserving zero-padding.  Falls back to a ``_int<n>`` suffix when no
+    trailing number is found.
+
+    Examples:
+        make_output_filename("img_001.tif", 0, ".tif") -> "img_002.tif"
+        make_output_filename("img_001.tif", 1, ".tif") -> "img_003.tif"
+        make_output_filename("image.tif",   0, ".tif") -> "image_int1.tif"
+    """
+    base_name = os.path.splitext(source_filename)[0]
+    match = re.search(r"(\d+)$", base_name)
+    if match:
+        number_part = match.group(1)
+        new_number = str(int(number_part) + (idx + 1)).zfill(len(number_part))
+        return f"{base_name[: -len(number_part)]}{new_number}{file_extension}"
+    return f"{base_name}_int{idx + 1}{file_extension}"

--- a/main.py
+++ b/main.py
@@ -1,49 +1,65 @@
 import argparse
 import os
+
 import tensorflow as tf
 
-# Import your functions
-from interpolation.interpolation_function_auto import *
-from interpolation.interpolation_function_skip import *
-from interpolation.interpolation_functions_no_skip import *
+from interpolation import (
+    interpolate_from_image_list,
+    interpolate_from_image_stack_no_skip,
+    interpolate_from_image_stack_skip,
+    list_skip_images,
+)
+
 
 def load_model():
     model_path = os.path.join("interpolation", "model")
     if not os.path.exists(model_path):
-        raise FileNotFoundError(f"Model not found at {model_path}")
-    model = tf.saved_model.load(model_path)
-    return model
+        raise FileNotFoundError(
+            f"Model not found at '{model_path}'. "
+            "Download the model folder from the link in the README and place it at interpolation/model."
+        )
+    return tf.saved_model.load(model_path)
 
-def run_auto(tile_size, pth, model):
-    image_files = [f for f in os.listdir(pth) if f.endswith(('tif', 'png', 'jpg'))]
+
+def run_auto(tile_size, pth, model, output_dir=None):
+    image_files = [f for f in os.listdir(pth) if f.endswith(("tif", "png", "jpg"))]
+    if not image_files:
+        raise ValueError(f"No .tif/.png/.jpg images found in '{pth}'")
     skip_images = list_skip_images(pth)
-    interpolate_from_image_list(pth, skip_images, tile_size, model, image_files)
+    if not skip_images:
+        print("No missing images detected in sequence — nothing to interpolate.")
+        return
+    interpolate_from_image_list(pth, skip_images, tile_size, model, image_files, output_dir=output_dir)
 
-def run_no_skip(tile_size, pth, skip, model):
-    image_files = [f for f in os.listdir(pth) if f.endswith(('tif', 'png', 'jpg'))]
-    interpolate_from_image_stack_no_skip(pth, skip, tile_size, model, image_files)
 
-def run_skip(tile_size, pth, skip, model):
-    image_files = [f for f in os.listdir(pth) if f.endswith(('tif', 'png', 'jpg'))]
-    interpolate_from_image_stack_skip(pth, skip, tile_size, model, image_files)
+def run_no_skip(tile_size, pth, skip, model, output_dir=None):
+    image_files = [f for f in os.listdir(pth) if f.endswith(("tif", "png", "jpg"))]
+    if not image_files:
+        raise ValueError(f"No .tif/.png/.jpg images found in '{pth}'")
+    interpolate_from_image_stack_no_skip(pth, skip, tile_size, model, image_files, output_dir=output_dir)
+
+
+def run_skip(tile_size, pth, skip, model, output_dir=None):
+    image_files = [f for f in os.listdir(pth) if f.endswith(("tif", "png", "jpg"))]
+    if not image_files:
+        raise ValueError(f"No .tif/.png/.jpg images found in '{pth}'")
+    interpolate_from_image_stack_skip(pth, skip, tile_size, model, image_files, output_dir=output_dir)
+
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Run interpolation modes from CLI")
-    parser.add_argument("--mode", choices=["auto", "no_skip", "skip"], required=True, help="Choose a mode")
-    parser.add_argument("--tile_size", type=int, nargs=2, required=True, help="Tile size (e.g., --tile_size 1024 1024)")
-    parser.add_argument("--pth", type=str, required=True, help="Path to image folder")
-    parser.add_argument('--skip', nargs='+', type=int, default=[1], help='Skip values')
+    parser = argparse.ArgumentParser(description="InterpolAI — AI-based image sequence interpolation")
+    parser.add_argument("--mode", choices=["auto", "no_skip", "skip"], required=True, help="Interpolation mode")
+    parser.add_argument("--tile_size", type=int, nargs=2, required=True, metavar=("H", "W"), help="Tile size for large images, e.g. --tile_size 1024 1024")
+    parser.add_argument("--pth", type=str, required=True, help="Path to the folder containing input images")
+    parser.add_argument("--output", type=str, default=None, help="Root folder for output subfolders (default: same as --pth)")
+    parser.add_argument("--skip", nargs="+", type=int, default=[1], help="Skip values for no_skip/skip modes (default: 1)")
 
     args = parser.parse_args()
     model = load_model()
 
     if args.mode == "auto":
-        run_auto(tuple(args.tile_size), args.pth, model)
+        run_auto(tuple(args.tile_size), args.pth, model, output_dir=args.output)
     elif args.mode == "no_skip":
-        if args.skip is None:
-            raise ValueError("Skip value is required for no_skip mode")
-        run_no_skip(tuple(args.tile_size), args.pth, args.skip, model)
+        run_no_skip(tuple(args.tile_size), args.pth, args.skip, model, output_dir=args.output)
     elif args.mode == "skip":
-        if args.skip is None:
-            raise ValueError("Skip value is required for skip mode")
-        run_skip(tuple(args.tile_size), args.pth, args.skip, model)
+        run_skip(tuple(args.tile_size), args.pth, args.skip, model, output_dir=args.output)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@
 tensorflow<2.11
 numpy==1.26.4
 imageio
+Pillow
 natsort
 tqdm
 jupyter

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,156 @@
+"""Tests for model-free utility functions.
+
+These tests do not require TensorFlow or the model weights — they cover the
+pure-Python / NumPy helpers that can be validated in CI without a GPU.
+"""
+
+import numpy as np
+import pytest
+
+from interpolation.utils import (
+    extract_number_from_filename,
+    make_output_filename,
+    pad_and_tile_image,
+    stitch_tiles,
+)
+from interpolation.interpolation_function_auto import list_skip_images
+
+
+# ---------------------------------------------------------------------------
+# extract_number_from_filename
+# ---------------------------------------------------------------------------
+
+class TestExtractNumber:
+    def test_simple_trailing_number(self):
+        assert extract_number_from_filename("img_001.tif") == 1
+
+    def test_number_at_end_of_stem(self):
+        assert extract_number_from_filename("frame42.png") == 42
+
+    def test_no_number_returns_none(self):
+        assert extract_number_from_filename("image.tif") is None
+
+    def test_multiple_numbers_returns_last(self):
+        # "series2_frame010" — last number is 010 → 10
+        assert extract_number_from_filename("series2_frame010.tif") == 10
+
+    def test_zero_padded(self):
+        assert extract_number_from_filename("z_0007.tif") == 7
+
+
+# ---------------------------------------------------------------------------
+# make_output_filename
+# ---------------------------------------------------------------------------
+
+class TestMakeOutputFilename:
+    def test_numbered_first_interpolation(self):
+        assert make_output_filename("img_001.tif", 0, ".tif") == "img_002.tif"
+
+    def test_numbered_second_interpolation(self):
+        assert make_output_filename("img_001.tif", 1, ".tif") == "img_003.tif"
+
+    def test_preserves_zero_padding(self):
+        assert make_output_filename("frame_010.png", 0, ".png") == "frame_011.png"
+
+    def test_fallback_suffix_when_no_trailing_number(self):
+        assert make_output_filename("image.tif", 0, ".tif") == "image_int1.tif"
+
+    def test_fallback_second_interpolation(self):
+        assert make_output_filename("image.tif", 2, ".tif") == "image_int3.tif"
+
+
+# ---------------------------------------------------------------------------
+# pad_and_tile_image
+# ---------------------------------------------------------------------------
+
+class TestPadAndTileImage:
+    def test_exact_fit_no_padding(self):
+        image = np.zeros((256, 256, 3), dtype=np.float32)
+        tiles, (pad_h, pad_w) = pad_and_tile_image(image, (256, 256))
+        assert pad_h == 0
+        assert pad_w == 0
+        assert tiles.shape == (1, 1, 256, 256, 3)
+
+    def test_needs_padding_produces_correct_shape(self):
+        image = np.zeros((300, 400, 3), dtype=np.float32)
+        tiles, (pad_h, pad_w) = pad_and_tile_image(image, (256, 256))
+        # 300 -> padded to 512 (2 tiles), 400 -> padded to 512 (2 tiles)
+        assert tiles.shape == (2, 2, 256, 256, 3)
+        assert pad_h == 256 - (300 % 256)  # 212
+        assert pad_w == 256 - (400 % 256)  # 112
+
+    def test_pixel_values_preserved_in_first_tile(self):
+        image = np.random.rand(256, 256, 3).astype(np.float32)
+        tiles, (pad_h, pad_w) = pad_and_tile_image(image, (256, 256))
+        assert pad_h == 0 and pad_w == 0
+        np.testing.assert_array_equal(tiles[0, 0], image)
+
+    def test_padding_region_is_zero(self):
+        image = np.ones((100, 100, 3), dtype=np.float32)
+        tiles, (pad_h, pad_w) = pad_and_tile_image(image, (256, 256))
+        assert pad_h == 156 and pad_w == 156
+        # Bottom-right corner of the single tile should be zero (padding)
+        assert tiles[0, 0, 200, 200, 0] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# stitch_tiles (roundtrip with pad_and_tile_image)
+# ---------------------------------------------------------------------------
+
+class TestStitchTiles:
+    def test_roundtrip_exact_fit(self):
+        image = np.random.rand(512, 512, 3).astype(np.float32)
+        tiles, (pad_h, pad_w) = pad_and_tile_image(image, (256, 256))
+        reconstructed = stitch_tiles(tiles, pad_h, pad_w, (256, 256))
+        np.testing.assert_array_almost_equal(reconstructed, image)
+
+    def test_roundtrip_with_padding(self):
+        """Tile → stitch should recover the original shape and values exactly."""
+        image = np.random.rand(300, 400, 3).astype(np.float32)
+        tiles, (pad_h, pad_w) = pad_and_tile_image(image, (256, 256))
+        reconstructed = stitch_tiles(tiles, pad_h, pad_w, (256, 256))
+        assert reconstructed.shape == image.shape
+        np.testing.assert_array_almost_equal(reconstructed, image)
+
+    def test_roundtrip_single_channel(self):
+        image = np.random.rand(128, 128, 1).astype(np.float32)
+        tiles, (pad_h, pad_w) = pad_and_tile_image(image, (64, 64))
+        reconstructed = stitch_tiles(tiles, pad_h, pad_w, (64, 64))
+        assert reconstructed.shape == image.shape
+        np.testing.assert_array_almost_equal(reconstructed, image)
+
+
+# ---------------------------------------------------------------------------
+# list_skip_images
+# ---------------------------------------------------------------------------
+
+class TestListSkipImages:
+    def test_detects_single_missing_image(self, tmp_path):
+        # z_001, z_002, z_004, z_005 — z_003 is missing
+        for n in [1, 2, 4, 5]:
+            (tmp_path / f"z_{n:03d}.tif").touch()
+        result = list_skip_images(str(tmp_path))
+        # gap between 2 and 4 → skip_index = 4 - 2 - 1 = 1
+        assert 1 in result
+        assert [2, 4] in result[1]
+
+    def test_no_missing_images_returns_empty(self, tmp_path):
+        for n in [1, 2, 3]:
+            (tmp_path / f"z_{n:03d}.tif").touch()
+        result = list_skip_images(str(tmp_path))
+        assert result == {}
+
+    def test_multiple_gaps_different_sizes(self, tmp_path):
+        # z_001, z_003, z_006 → gap of 1 between 1–3, gap of 2 between 3–6
+        for n in [1, 3, 6]:
+            (tmp_path / f"z_{n:03d}.tif").touch()
+        result = list_skip_images(str(tmp_path))
+        assert 1 in result   # one image missing between 1 and 3
+        assert 2 in result   # two images missing between 3 and 6
+
+    def test_ignores_non_image_files(self, tmp_path):
+        for n in [1, 2, 3]:
+            (tmp_path / f"z_{n:03d}.tif").touch()
+        (tmp_path / "notes.txt").touch()
+        result = list_skip_images(str(tmp_path))
+        assert result == {}


### PR DESCRIPTION
## Summary

- **Extracted shared utilities** into `interpolation/utils.py` — `load_image`, `pad_and_tile_image`, `stitch_tiles`, `extract_number_from_filename`, and a new `make_output_filename` helper. Removes ~80 lines of code duplicated identically across all three interpolation modules.
- **Made `interpolation/` a proper package** by adding `__init__.py` with explicit public exports.
- **Fixed wildcard imports** in `main.py` → explicit named imports.
- **Added `--output` flag** to `main.py` so results can be written to a separate directory.
- **Added input validation**: clear error if image folder is empty; no-op message if auto mode finds nothing to do.
- **Added `Pillow` to `requirements.txt`** — it was imported but undeclared.
- **Fixed README** usage examples: replaced hardcoded internal lab paths (`\\10.99.68.178\...`) with generic `/path/to/your/images`, added a CLI reference table.

## Tests

21 new tests in `tests/test_utils.py` covering all model-free functions. All pass without TensorFlow or model weights.

## CI

`.github/workflows/ci.yml` runs tests on every push and PR (Python 3.9, ubuntu-latest, no GPU needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)